### PR TITLE
Add "no_newline()" function to widgets that keeps the next widget on the same line

### DIFF
--- a/Documentation/Classes/Checkbox.md
+++ b/Documentation/Classes/Checkbox.md
@@ -42,6 +42,10 @@ Sets the left indentation for the checkbox.
   - `$indent : Integer` - The indentation in pixels.
 - **Returns**: `cs.Checkbox` - The current checkbox widget instance.
 
+### `no_newline() : cs.Checkbox`
+Sets the checkbox to not force a new line after the checkbox. Useful if you want the next widget to be on the same 'line'.
+- **Returns**: `cs.Checkbox` - The current checkbox widget instance.
+
 ### `is_checked() : cs.Checkbox`
 Sets the checkbox to be initially checked.
 - **Returns**: `cs.Checkbox` - The current checkbox widget instance.

--- a/Documentation/Classes/Input.md
+++ b/Documentation/Classes/Input.md
@@ -60,33 +60,39 @@ Sets the initial value of the input field.
   - `$value : Text` - The initial text value.
 - **Returns**: `cs.Input` - The current input widget instance.
 
+### `no_newline() : cs.Input`
+Sets the input field to not force a new line after the input. Useful if you want the next widget to be on the same 'line'.
+- **Returns**: `cs.Input` - The current input widget instance.
+
 
 ## Usage Example
 ```4d
-vvar $dialog : cs.Dialog
+var $dialog : cs.Dialog
 $dialog:=cs.Dialog.new()\
-   .default_font_size(13)\
-   .width(500)\
-   .ok_button("Continue")\
-   .cancel_button("Cancel")\
-   .other_button("A 3rd Option")
+  .default_font_size(14)\
+  .width(600)\
+  .ok_button("Continue")\
+  .cancel_button("Cancel")
 
-cs.Text.new($dialog; "Header for dialog").bold().size(18)
-cs.Text.new($dialog; "Some text. Like a paragraph.").indent(20)
+cs.Text.new($dialog; "Personal Information Request").bold().size(20)
+cs.Text.new($dialog; "This is a test of the Dialog component on a mockup of a dialog that asks the user for some personal information using a few different input methods.").indent(20)
+
 cs.Blank_Line.new($dialog)
-cs.Text.new($dialog; "Select one of the following").bold()
-cs.Checkbox.new($dialog; "Checkbox #1").name("cb_1").indent(20).is_checked()
-cs.Checkbox.new($dialog; "Checkbox #2").name("cb_2").indent(20)
-cs.Checkbox.new($dialog; "Checkbox #3").name("cb_3").indent(20).is_checked()
-cs.Checkbox.new($dialog; "Checkbox #4").name("cb_4").indent(20)
-cs.Checkbox.new($dialog; "Checkbox #5 - no name").indent(20)
-cs.Text.new($dialog; "please select one").italic().size(10).indent(20)
-cs.Blank_Line.new($dialog)
-cs.Text.new($dialog; "Type your name:").bold()
-cs.Input.new($dialog).name("first_name").value("Dude").indent(20).width(150).size(24)
+
+cs.Text.new($dialog; "Name:").bold().no_newline()
+cs.Input.new($dialog).name("first_name")\
+  .placeholder("First Name").width(120).no_newline()
 cs.Input.new($dialog).name("last_name")\
-   .placeholder("Last Name").indent(20).width(250)\
-   .bold()
+  .placeholder("Last Name").width(150)
+
+cs.Blank_Line.new($dialog)
+
+cs.Text.new($dialog; "Select one of the following").bold()
+cs.Checkbox.new($dialog; "Checkbox #1").name("cb_1").indent(40).is_checked().no_newline()
+cs.Checkbox.new($dialog; "Checkbox #2").name("cb_2").indent(40)
+cs.Checkbox.new($dialog; "Checkbox #3").name("cb_3").indent(40).is_checked().no_newline()
+cs.Checkbox.new($dialog; "Checkbox #4").name("cb_4").indent(40)
+cs.Checkbox.new($dialog; "Checkbox #5 - no name").indent(40)
 
 var $form_data : Object
 $form_data:=$dialog.display()

--- a/Documentation/Classes/Text.md
+++ b/Documentation/Classes/Text.md
@@ -33,6 +33,10 @@ Sets the left indentation for the text.
   - `$indent : Integer` - The indentation in pixels.
 - **Returns**: `cs.Text` - The current text widget instance.
 
+### `no_newline() : cs.Text`
+Sets the text to not force a new line after the text. Useful if you want the next widget to be on the same 'line'.
+- **Returns**: `cs.Text` - The current text widget instance.
+
 ## Usage Example
 ```4d
 var $dialog : cs.Dialog

--- a/Project/Sources/Classes/Checkbox.4dm
+++ b/Project/Sources/Classes/Checkbox.4dm
@@ -44,6 +44,10 @@ Function is_checked() : cs:C1710.Checkbox
 	This:C1470._is_checked:=True:C214
 	return This:C1470
 	
+Function no_newline() : cs:C1710.Checkbox
+	Super:C1706.no_newline()
+	return This:C1470
+	
 	
 	//Mark:-************ PRIVATE FUNCTIONS
 Function _widget_json()->$widget : Object

--- a/Project/Sources/Classes/Dialog.4dm
+++ b/Project/Sources/Classes/Dialog.4dm
@@ -230,7 +230,7 @@ Function _get_text_best_size($text : Text; $options : Object)->$best_size : Obje
 	
 Function _append_widgets_to_form()
 	var $id : Text
-	var $index : Integer
+	var $index; $widget_indent : Integer
 	var $widgets : cs:C1710._widget
 	var $add_newline : Boolean
 	var $widget_object : Object
@@ -241,6 +241,7 @@ Function _append_widgets_to_form()
 		$id:="widget_"+String:C10($index)
 		
 		$widget_object:=$widgets._widget_json()
+		$widget_indent:=$widget_object.left
 		$widget_object.top:=This:C1470._top_next_widget
 		$widget_object.left+=20
 		If ($widget_object.fontSize=Null:C1517)
@@ -261,7 +262,7 @@ Function _append_widgets_to_form()
 			$next_left_position:=0  // reset these
 			$widget_max_height:=0  // reset these
 		Else 
-			$next_left_position+=$widget_object.width+10
+			$next_left_position+=$widget_object.width+10+$widget_indent
 		End if 
 		
 		This:C1470._form.pages[1].objects[$id]:=$widget_object

--- a/Project/Sources/Classes/Dialog.4dm
+++ b/Project/Sources/Classes/Dialog.4dm
@@ -232,7 +232,10 @@ Function _append_widgets_to_form()
 	var $id : Text
 	var $index : Integer
 	var $widgets : cs:C1710._widget
+	var $add_newline : Boolean
 	var $widget_object : Object
+	var $widget_max_height : Integer
+	var $next_left_position : Integer
 	For each ($widgets; This:C1470._widgets)
 		$index+=1
 		$id:="widget_"+String:C10($index)
@@ -243,9 +246,24 @@ Function _append_widgets_to_form()
 		If ($widget_object.fontSize=Null:C1517)
 			$widget_object.fontSize:=This:C1470._default_font_size
 		End if 
+		If (Not:C34($add_newline))
+			$widget_object.left+=$next_left_position
+		End if 
+		
+		If ($widget_max_height<$widget_object.height)
+			$widget_max_height:=$widget_object.height
+		End if 
+		
+		$add_newline:=$widgets._append_newline
+		If ($add_newline)
+			This:C1470._top_next_widget+=$widget_max_height
+			This:C1470._top_next_widget+=10  // gap
+			$next_left_position:=0  // reset these
+			$widget_max_height:=0  // reset these
+		Else 
+			$next_left_position+=$widget_object.width+10
+		End if 
 		
 		This:C1470._form.pages[1].objects[$id]:=$widget_object
-		This:C1470._top_next_widget+=$widget_object.height
-		This:C1470._top_next_widget+=10  // gap
 	End for each 
 	

--- a/Project/Sources/Classes/Input.4dm
+++ b/Project/Sources/Classes/Input.4dm
@@ -54,6 +54,10 @@ Function value($value : Text) : cs:C1710.Input
 	This:C1470._value:=$value
 	return This:C1470
 	
+Function no_newline() : cs:C1710.Input
+	Super:C1706.no_newline()
+	return This:C1470
+	
 	
 	//Mark:-************ PRIVATE FUNCTIONS
 Function _widget_json()->$widget : Object

--- a/Project/Sources/Classes/Text.4dm
+++ b/Project/Sources/Classes/Text.4dm
@@ -32,6 +32,10 @@ Function indent($indent : Integer) : cs:C1710.Text
 	This:C1470._options.indent:=$indent
 	return This:C1470
 	
+Function no_newline() : cs:C1710.Text
+	Super:C1706.no_newline()
+	return This:C1470
+	
 	
 	//Mark:-************ PRIVATE FUNCTIONS
 Function _widget_json()->$widget : Object

--- a/Project/Sources/Classes/_widget.4dm
+++ b/Project/Sources/Classes/_widget.4dm
@@ -13,7 +13,7 @@ Class constructor($dialog : cs:C1710.Dialog)
 	
 	
 	//Mark:-************ PUBLIC FUNCTIONS
-Function no_newline() : cs:C1710.Text
+Function no_newline() : cs:C1710._widget
 	This:C1470._append_newline:=False:C215
 	return This:C1470
 	

--- a/Project/Sources/Classes/_widget.4dm
+++ b/Project/Sources/Classes/_widget.4dm
@@ -1,15 +1,21 @@
 // cs._widget
 
-property _dialog : cs:C1710.Dialog
 property _json : Text
+property _dialog : cs:C1710.Dialog
+property _append_newline : Boolean
+
 
 Class constructor($dialog : cs:C1710.Dialog)
 	$dialog._add_widget(This:C1470)
+	This:C1470._append_newline:=True:C214
 	This:C1470._dialog:=$dialog
 	This:C1470._json:=""
 	
 	
 	//Mark:-************ PUBLIC FUNCTIONS
+Function no_newline() : cs:C1710.Text
+	This:C1470._append_newline:=False:C215
+	return This:C1470
 	
 	
 	

--- a/Project/Sources/Methods/_TEST_forms.4dm
+++ b/Project/Sources/Methods/_TEST_forms.4dm
@@ -1,0 +1,30 @@
+//%attributes = {}
+var $dialog : cs:C1710.Dialog
+$dialog:=cs:C1710.Dialog.new()\
+.default_font_size(14)\
+.width(600)\
+.ok_button("Continue")\
+.cancel_button("Cancel")
+
+cs:C1710.Text.new($dialog; "Personal Information Request").bold().size(20)
+cs:C1710.Text.new($dialog; "This is a test of the Dialog component on a mockup of a dialog that asks the user for some personal information using a few different input methods.").indent(20)
+
+cs:C1710.Blank_Line.new($dialog)
+
+cs:C1710.Text.new($dialog; "Name:").bold().no_newline()
+cs:C1710.Input.new($dialog).name("first_name")\
+.placeholder("First Name").width(120).no_newline()
+cs:C1710.Input.new($dialog).name("last_name")\
+.placeholder("Last Name").width(150)
+
+cs:C1710.Blank_Line.new($dialog)
+
+cs:C1710.Text.new($dialog; "Select one of the following").bold()
+cs:C1710.Checkbox.new($dialog; "Checkbox #1").name("cb_1").indent(40).is_checked().no_newline()
+cs:C1710.Checkbox.new($dialog; "Checkbox #2").name("cb_2").indent(40)
+cs:C1710.Checkbox.new($dialog; "Checkbox #3").name("cb_3").indent(40).is_checked().no_newline()
+cs:C1710.Checkbox.new($dialog; "Checkbox #4").name("cb_4").indent(40)
+cs:C1710.Checkbox.new($dialog; "Checkbox #5 - no name").indent(40)
+
+var $form_data : Object
+$form_data:=$dialog.display()

--- a/Project/Sources/Methods/_TEST_forms.4dm
+++ b/Project/Sources/Methods/_TEST_forms.4dm
@@ -1,4 +1,29 @@
 //%attributes = {}
+$dialog:=cs:C1710.Dialog.new()\
+.width(500)\
+.auto_cancel_in_seconds(5*60)\
+.ok_button("Submit")\
+.cancel_button("Cancel")
+
+cs:C1710.Text.new($dialog; "Export Treatment Notes for District").bold().size(14)
+cs:C1710.Blank_Line.new($dialog)
+
+cs:C1710.Text.new($dialog; "District ID").no_newline().bold().indent(40)
+cs:C1710.Input.new($dialog).name("district_id").placeholder("District ID").width(50)
+
+cs:C1710.Text.new($dialog; "Start Date").no_newline().bold().indent(40)
+cs:C1710.Input.new($dialog).name("start_date").placeholder("MM/DD/YYYY").width(120)
+
+cs:C1710.Text.new($dialog; "End Date").no_newline().bold().indent(40)
+cs:C1710.Input.new($dialog).name("end_date").placeholder("MM/DD/YYYY").width(120)
+
+var $district_id; $end_date; $start_date : Integer
+var $form_data : Object
+$form_data:=$dialog.display()
+
+
+
+
 var $dialog : cs:C1710.Dialog
 $dialog:=cs:C1710.Dialog.new()\
 .default_font_size(14)\

--- a/Resources/build.json
+++ b/Resources/build.json
@@ -1,1 +1,1 @@
-{"releaseYear":"2025","releaseNo":"r2","buildNo":"20250708","versionShort":"2025.r2","versionLong":"2025.r2 (build 20250708)"}
+{"releaseYear":"2025","releaseNo":"r3","buildNo":"20250714","versionShort":"2025.r3","versionLong":"2025.r3 (build 20250714)"}

--- a/Resources/componentManifest.json
+++ b/Resources/componentManifest.json
@@ -1,8 +1,8 @@
 ﻿{
 	"author": "Dani Beaubien",
 	"copyrights": "Copyright 2025 Open Road Development Inc.",
-	"version": "2025.r2 (build 20250708)",
-	"buildDate": "2025-07-08",
+	"version": "2025.r3 (build 20250714)",
+	"buildDate": "2025-07-14",
 	"url": "http://openroaddevelopment.com",
 	"manifestFormatVersion": "1.0",
 	"buildWith4DVersion": "v20.6 final (build 101680)",

--- a/Resources/en.lproj/syntaxEN.json
+++ b/Resources/en.lproj/syntaxEN.json
@@ -210,6 +210,17 @@
 		}
 	},
 	"Input": {
+		"no_newline()": {
+			"Syntax": "**.no_newline**() : cs.Dialog.Input",
+			"Params": [
+				[
+					"",
+					"cs.Dialog.Input",
+					"<-"
+				]
+			],
+			"Summary": ""
+		},
 		"width()": {
 			"Syntax": "**.width**( *width* : Integer ) : cs.Dialog.Input",
 			"Params": [
@@ -415,7 +426,19 @@
 		"_inheritedFrom_": "_widget"
 	},
 	"Blank_Line": {},
-	"_widget": {},
+	"_widget": {
+		"no_newline()": {
+			"Syntax": "**.no_newline**() : cs.Dialog.Text",
+			"Params": [
+				[
+					"",
+					"cs.Dialog.Text",
+					"<-"
+				]
+			],
+			"Summary": ""
+		}
+	},
 	"Text": {
 		"size()": {
 			"Syntax": "**.size**( *size* : Integer ) : cs.Dialog.Text",
@@ -425,6 +448,17 @@
 					"Integer",
 					"->"
 				],
+				[
+					"",
+					"cs.Dialog.Text",
+					"<-"
+				]
+			],
+			"Summary": ""
+		},
+		"no_newline()": {
+			"Syntax": "**.no_newline**() : cs.Dialog.Text",
+			"Params": [
 				[
 					"",
 					"cs.Dialog.Text",

--- a/Resources/en.lproj/syntaxEN.json
+++ b/Resources/en.lproj/syntaxEN.json
@@ -358,6 +358,17 @@
 			],
 			"Summary": ""
 		},
+		"no_newline()": {
+			"Syntax": "**.no_newline**() : cs.Dialog.Checkbox",
+			"Params": [
+				[
+					"",
+					"cs.Dialog.Checkbox",
+					"<-"
+				]
+			],
+			"Summary": ""
+		},
 		"indent()": {
 			"Syntax": "**.indent**( *indent* : Integer ) : cs.Dialog.Checkbox",
 			"Params": [
@@ -428,11 +439,11 @@
 	"Blank_Line": {},
 	"_widget": {
 		"no_newline()": {
-			"Syntax": "**.no_newline**() : cs.Dialog.Text",
+			"Syntax": "**.no_newline**() : cs.Dialog._widget",
 			"Params": [
 				[
 					"",
-					"cs.Dialog.Text",
+					"cs.Dialog._widget",
 					"<-"
 				]
 			],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new method to keep widgets (such as text, input fields, and checkboxes) on the same line in dialog forms, allowing for more flexible horizontal layouts.

* **Documentation**
  * Updated documentation to describe the new inline layout method and revised usage examples to demonstrate inline widget arrangement.

* **Chores**
  * Updated version and build metadata for the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->